### PR TITLE
Ruby 1.9 patch for jcode

### DIFF
--- a/lib/webbynode/command.rb
+++ b/lib/webbynode/command.rb
@@ -1,6 +1,6 @@
 begin
   require 'jcode'
-rescue
+rescue LoadError
 end
 
 module Webbynode


### PR DESCRIPTION
Ruby 1.9 doesn't have jcode and LoadError must be explicitly called. A naked rescue only catches StandardError.
