### PR TITLE
Updated git.clean? method to support when git statusHints are turned off.

### DIFF
--- a/lib/webbynode/git.rb
+++ b/lib/webbynode/git.rb
@@ -24,7 +24,7 @@ module Webbynode
     end
     
     def clean?
-      io.exec("git status") =~ /working directory clean/
+      io.exec("git status") =~ /nothing to commit/
     end
     
     def delete_file(file)


### PR DESCRIPTION
This is a patch for issue #59. If the user has used the following git configuration command:

```
$ git config --global advice.statusHints false
```

Then the output from `git status` does not include the phrase 'working directory clean'. I've updated the `.clean?` method to look match on the phrase 'nothing to commit' which appears whether statusHints is turned on or off.
